### PR TITLE
Updates to README, and check_by_winrm.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ It strikes me that people are going to be eager to get something running over Wi
 
 But for *testing purposes*, here's how we can configure WinRM, so we can execute Nagios plugins via WinRM.
 On your Windows system, in a Powershell terminal, run the following commands:
-`winrm set winrm/config/service @{Basic="true"}`
-`winrm set winrm/config/service/auth @{Basic="true"}`
+
+`winrm set winrm/config/service '@{Basic="true"}'`
+
+`winrm set winrm/config/service/auth '@{Basic="true"}'`
 
 What have we done here? The transport is going to be basic HTTP, and the authentication is going to be plaintext. Technically it's base64 encoded, but for those not in the know, you run a password through a base64 encoder, you get the base64 string. You run a base64 string through a base64 encoder, you get the password. No tricks, no keys, no hashes, no gods, no masters. Please do not do this in production.
 

--- a/check_by_winrm/check_by_winrm.py
+++ b/check_by_winrm/check_by_winrm.py
@@ -13,10 +13,11 @@ logger = logging.getLogger(__name__)
 
 try:
     # Parse command-line arguments
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description='check_by_winrm.py executes a Nagios or Nagios compatible plugin on a remote, Windows-based system. It is assumed that the plugin you wish to execute already exists on the Windows system.')
     parser.add_argument('-H', '--host', required=True, type=str, help='IP address or host name of the Windows system.')
     parser.add_argument('-u', '--user', required=True, type=str, help='Username for connecting to the Windows system.')
-    parser.add_argument('-a', '--auth', required=True, type=str, choices=['cert', 'kerberos', 'credssp'], help='Authentication mechanism for the Windows system.')
+    parser.add_argument('-a', '--auth', required=True, type=str, choices=['cert', 'kerberos', 'credssp', 'basic-http', 'basic-https'], help='Authentication mechanism for the Windows system. Strongly recommended you avoid basic-http.')
+    parser.add_argument('-p', '--password', required=False, type=str, help='Optionally, you can present the password as a command line argument.')
     parser.add_argument('-P', '--plugin', required=True, type=str, help='Full path to plugin on the Windows system. (e.g. C:\plugins\check_memory.py)')
     parser.add_argument('-A', '--args', required=False, type=str, help='Additional arguments for the specified plugin. (e.g. -outputtype GB -metric Used -warning 12 -critical 14)')
     parser.add_argument('-s', '--silent', action='store_true', help='Silent mode without printing to stdout.')
@@ -34,6 +35,9 @@ if not any(vars(args).values()):
     exit(1)
 
 password = None
+
+if args.password is not None:
+    password = args.password
 
 if not password:
     # Prompt for password input securely
@@ -64,7 +68,15 @@ try:
 
     elif args.auth == 'credssp':
         # Use CredSSP Authentication
-        authentication = winrm.transport.CredSSPTransport()
+        authentication = 'credssp'
+
+    elif args.auth == 'basic-http':
+        # Use basic-http Authentication
+        authentication = 'basic'
+
+    elif args.auth == 'basic-https':
+        # Use basic-https Authentication
+        authentication = 'ssl'
 
     # Create a WinRM session with the provided host, user, password, and authentication method
     winrmsession = winrm.Session(args.host, auth=(args.user, password), transport=authentication)
@@ -77,8 +89,23 @@ try:
             # Print the standard output of the command if not in silent mode
             print(command.std_out.decode('utf-8').rstrip('\n'))
 
+    service_state = 3
+
+    # Need to parse the output to find the command's status code as PyWinrm or WinRM in general just returns 0 or 1.
+    if "CRITICAL" in command.std_out.decode('utf-8'):
+        service_state = 2
+
+    elif "WARNING" in command.std_out.decode('utf-8'):
+        service_state = 1
+
+    elif "UNKNOWN" in command.std_out.decode('utf-8'):
+        service_state = 3
+
+    else:
+        service_state = 0
+
     # Exit with the command's status code
-    exit(command.status_code)
+    exit(service_state)
 
 except winrm.exceptions.WinRMTransportError as e:
     logger.error(f"WinRM transport error: {str(e)}")


### PR DESCRIPTION
- Bringing back basic auth.
- Updating README's `winrm` commands, adding single quotes around the key that needs to be changed.
- Added back parsing of the plugin output. Either pywinrm or just WinRM in general only returns a 0 or 1 for a status code. Not sure what's up with that.
- Added a description for the argument parser
