### PR TITLE
Code cleanup. Changing write-hosts to write-outputs

### DIFF
--- a/check_cpu.ps1
+++ b/check_cpu.ps1
@@ -73,5 +73,5 @@ $processArray = processCheck -checkResult $cpuusage `
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode

--- a/check_disks.ps1
+++ b/check_disks.ps1
@@ -90,5 +90,5 @@ $processArray = processCheck -checkResult $counterData `
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode

--- a/check_memory.ps1
+++ b/check_memory.ps1
@@ -116,5 +116,5 @@ $processArray = processCheck -checkResult $memoryresult `
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode

--- a/check_network_adapter.ps1
+++ b/check_network_adapter.ps1
@@ -187,5 +187,5 @@ $processArray = processCheck -checkResult $netresult `
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode

--- a/check_process.ps1
+++ b/check_process.ps1
@@ -119,5 +119,5 @@ switch ($metric) {
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode

--- a/check_service.ps1
+++ b/check_service.ps1
@@ -61,5 +61,5 @@ else {
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode

--- a/check_users.ps1
+++ b/check_users.ps1
@@ -83,5 +83,5 @@ else {
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode

--- a/check_volume.ps1
+++ b/check_volume.ps1
@@ -111,5 +111,5 @@ $processArray = processCheck -checkResult $volumeresult `
 $exitcode = $processArray[1]
 $exitMessage = $processArray[2]
 
-write-host $exitMessage
+write-output $exitMessage
 exit $exitcode


### PR DESCRIPTION
Word is that `write-host` is out, and `write-output` is in. I'm mainly doing this for some cleanup, but I'm hoping it will make some weirdness with check_by_winrm.py easier to deal with in the future.